### PR TITLE
Explicitly setting memory for uptimer command to match quota.

### DIFF
--- a/cfCmdGenerator/cfCmdGenerator.go
+++ b/cfCmdGenerator/cfCmdGenerator.go
@@ -123,6 +123,7 @@ func (c *cfCmdGenerator) Push(name, domain, path, command string) cmdStartWaiter
 				"-b", "binary_buildpack",
 				"-c", command,
 				"-i", "2",
+				"-m", "1024M",
 			),
 		),
 	)

--- a/cfCmdGenerator/cfCmdGenerator_test.go
+++ b/cfCmdGenerator/cfCmdGenerator_test.go
@@ -111,7 +111,7 @@ var _ = Describe("CfCmdGenerator", func() {
 
 	Describe("Push", func() {
 		It("Generates the correct command", func() {
-			expectedCmd := exec.Command("cf", "push", "appName", "-d", "apps.example.com", "-p", "path/to/app", "-b", "binary_buildpack", "-c", "./start-command", "-i", "2")
+			expectedCmd := exec.Command("cf", "push", "appName", "-d", "apps.example.com", "-p", "path/to/app", "-b", "binary_buildpack", "-c", "./start-command", "-i", "2", "-m", "1024M")
 			expectedCmd.Env = append(expectedCmd.Env, fmt.Sprintf("CF_HOME=%s", cfHome))
 			expectedCmd.Env = append(expectedCmd.Env, "CF_STAGING_TIMEOUT=1")
 


### PR DESCRIPTION
Fails if default memory is greater that 1024M (https://bosh.io/jobs/cloud_controller_ng?source=github.com/cloudfoundry/capi-release&version=1.50.0#p=cc.default_app_memory)