### PR TITLE
adds support for targeting an isolation segment other then 'shared'

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Here is an example config `json`:
         "admin_user": "admin",
         "admin_password": "PASS",
         "tcp_domain": "tcp.my-cf.com",
-        "available_port": 1025
+        "available_port": 1025,
+        "isolation_segment": "production"
     },
     "optional_tests": {
       "run_app_syslog_availability": true
@@ -101,6 +102,9 @@ during test setup.
 The `tcp_domain` and `available_port` values
 are not required
 _unless_ you elect to run the `app_syslog_availability` test.
+
+`isolation_segment` is not required. 
+Setting it allows you to target a different isolation segment other than `shared`.
 
 ### Optional tests (optional)
 The `optional_tests` section is optional,

--- a/cfCmdGenerator/cfCmdGenerator.go
+++ b/cfCmdGenerator/cfCmdGenerator.go
@@ -28,6 +28,8 @@ type CfCmdGenerator interface {
 	CreateUserProvidedService(serviceName, syslogURL string) cmdStartWaiter.CmdStartWaiter
 	BindService(appName, serviceName string) cmdStartWaiter.CmdStartWaiter
 	Restage(appName string) cmdStartWaiter.CmdStartWaiter
+	EnableOrgIsolation(orgName, segmentName string) cmdStartWaiter.CmdStartWaiter
+	SetSpaceIsolation(spaceName, segmentName string) cmdStartWaiter.CmdStartWaiter
 }
 
 type cfCmdGenerator struct {
@@ -212,6 +214,22 @@ func (c *cfCmdGenerator) Restage(appName string) cmdStartWaiter.CmdStartWaiter {
 	return c.addCfHome(
 		exec.Command(
 			"cf", "restage", appName,
+		),
+	)
+}
+
+func (c *cfCmdGenerator) EnableOrgIsolation(orgName string, segmentName string) cmdStartWaiter.CmdStartWaiter {
+	return c.addCfHome(
+		exec.Command(
+			"cf", "enable-org-isolation", orgName, segmentName,
+		),
+	)
+}
+
+func (c *cfCmdGenerator) SetSpaceIsolation(spaceName, segmentName string) cmdStartWaiter.CmdStartWaiter {
+	return c.addCfHome(
+		exec.Command(
+			"cf", "set-space-isolation-segment", spaceName, segmentName,
 		),
 	)
 }

--- a/cfCmdGenerator/cfCmdGenerator_test.go
+++ b/cfCmdGenerator/cfCmdGenerator_test.go
@@ -232,4 +232,28 @@ var _ = Describe("CfCmdGenerator", func() {
 			Expect(cmd).To(Equal(expectedCmd))
 		})
 	})
+
+	Describe("EnableOrgIsolation", func() {
+		It("Generates the correct command", func() {
+			expectedCmd := exec.Command("cf", "enable-org-isolation", "orgName", "segmentName")
+			expectedCmd.Env = []string{fmt.Sprintf("CF_HOME=%s", cfHome)}
+
+			cmd := generator.EnableOrgIsolation("orgName", "segmentName")
+
+			Expect(cmd).To(Equal(expectedCmd))
+		})
+	})
+
+	Describe("SetSpaceIsolation", func() {
+		It("Generates the correct command", func() {
+			expectedCmd := exec.Command("cf", "set-space-isolation-segment", "spaceName", "segmentName")
+			expectedCmd.Env = []string{fmt.Sprintf("CF_HOME=%s", cfHome)}
+
+			cmd := generator.SetSpaceIsolation("spaceName", "segmentName")
+
+			Expect(cmd).To(Equal(expectedCmd))
+
+		})
+	})
+
 })

--- a/cfWorkflow/cfWorkflow.go
+++ b/cfWorkflow/cfWorkflow.go
@@ -67,7 +67,7 @@ func New(cfConfig *config.Cf, org, space, quota, appName, appPath, appCommand st
 }
 
 func (c *cfWorkflow) Setup(ccg cfCmdGenerator.CfCmdGenerator) []cmdStartWaiter.CmdStartWaiter {
-	return []cmdStartWaiter.CmdStartWaiter{
+	cmds := []cmdStartWaiter.CmdStartWaiter{
 		ccg.Api(c.cf.API),
 		ccg.Auth(c.cf.AdminUser, c.cf.AdminPassword),
 		ccg.CreateOrg(c.org),
@@ -75,6 +75,17 @@ func (c *cfWorkflow) Setup(ccg cfCmdGenerator.CfCmdGenerator) []cmdStartWaiter.C
 		ccg.CreateQuota(c.quota),
 		ccg.SetQuota(c.org, c.quota),
 	}
+
+	if c.cf.IsolationSegment != "" {
+		cmds = append(
+			cmds,
+			ccg.EnableOrgIsolation(c.org, c.cf.IsolationSegment),
+			ccg.Target(c.org, c.space),
+			ccg.SetSpaceIsolation(c.space, c.cf.IsolationSegment),
+		)
+	}
+
+	return cmds
 }
 
 func (c *cfWorkflow) Push(ccg cfCmdGenerator.CfCmdGenerator) []cmdStartWaiter.CmdStartWaiter {

--- a/cfWorkflow/cfWorkflow_test.go
+++ b/cfWorkflow/cfWorkflow_test.go
@@ -117,6 +117,36 @@ var _ = Describe("CfWorkflow", func() {
 				},
 			))
 		})
+
+		Context("if a isolation segment is configured", func() {
+
+			BeforeEach(func(){
+				cfc.IsolationSegment = "someSegment"
+				cw = New(cfc, org, space, quota, appName, appPath, appCommand)
+			})
+
+
+			It("includes isolation segment related cmds", func() {
+
+				cmds := cw.Setup(ccg)
+
+				Expect(cmds).To(Equal(
+					[]cmdStartWaiter.CmdStartWaiter{
+						ccg.Api("jigglypuff.cf-app.com"),
+						ccg.Auth("pika", "chu"),
+						ccg.CreateOrg("someOrg"),
+						ccg.CreateSpace("someOrg", "someSpace"),
+						ccg.CreateQuota("someQuota"),
+						ccg.SetQuota("someOrg", "someQuota"),
+						ccg.EnableOrgIsolation("someOrg", "someSegment"),
+						ccg.Target("someOrg", "someSpace"),
+						ccg.SetSpaceIsolation("someSpace", "someSegment"),
+					},
+				))
+			})
+
+		})
+
 	})
 
 	Describe("TearDown", func() {

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,8 @@ type Cf struct {
 
 	TCPDomain     string `json:"tcp_domain"`
 	AvailablePort int    `json:"available_port"`
+
+	IsolationSegment string `json:"isolation_segment"`
 }
 
 type AllowedFailures struct {


### PR DESCRIPTION
This enables users to use uptimer to monitor updates to isolation segments other than `shared` as well. 