### PR TITLE
fix: frequent race condition in testing where two parallel processes try to listen on the same port

### DIFF
--- a/measurement/tcp_availability_test.go
+++ b/measurement/tcp_availability_test.go
@@ -23,7 +23,7 @@ var _ = Describe("TCPAvailability", func() {
 
 	BeforeEach(func() {
 		url = "localhost"
-		port = 6000
+		port = 6000 + GinkgoParallelProcess()
 
 		am = NewTCPAvailability(url, port)
 	})


### PR DESCRIPTION
Fixes a testing failure where parallel processes attempt to listen on the same port.